### PR TITLE
feat : KAKAO Login OAuth 및 Passport 추가

### DIFF
--- a/server/src/api/middlewares/passport/index.js
+++ b/server/src/api/middlewares/passport/index.js
@@ -1,0 +1,30 @@
+import passport from "passport";
+import kakaoStrategy from './kakaoStrategy.js';
+
+import Users from "../../../models/users.js";
+
+export default () => {
+
+    // 로그인 인증 성공 시 한 번만 실행
+    passport.serializeUser((user, done) => {
+        done(null, user.id);
+    });
+
+    // 로그인 인증이 되어 있는 경우, 요청할 때마다 실행
+    passport.deserializeUser(async (id, done) => {
+        // 세션에 저장되어 있는 id를 인자 값으로 전달 받음
+        try {
+            const user = await Users.findOne({
+                where: {id}
+            });
+            done(null, user); //req.user 생성
+        } catch {
+            done(null, false, {
+                msg: "서버 문제 발생"
+            });
+        };
+    });
+
+    // kakaoStrategy 등록.
+    kakaoStrategy();
+}

--- a/server/src/api/middlewares/passport/kakaoStrategy.js
+++ b/server/src/api/middlewares/passport/kakaoStrategy.js
@@ -1,0 +1,43 @@
+import passport from "passport";
+import { Strategy as KakaoStrategy} from "passport-kakao";
+import Users from "../../../models/users.js";
+
+const kakaoStrategy = () => {
+    passport.use(new KakaoStrategy(
+        {
+            clientID: process.env.KAKAO_ID, // 카카오 REST API KEY
+            callbackURL:'/api/kakao/callback', // 카카오 로그인 Redirect URI
+        },
+
+        async (accessToken, refreshToken, profile, done) => {
+            console.log('kakao profile', profile);
+            try {
+
+                // 회원 정보 찾기
+                const exUser = await Users.findOne({
+                    where: { email:profile.id, type: 'SOCIAL'}
+                });
+
+                // 카카오 가입이 되어 있다면
+                if (exUser) {
+                    done(null, exUser); // 로그인 인증 성공
+                } else {
+                    // 가입이되지 않은 유저라면 회원 가입시킨 후 로그인 시키기.
+                    const newUser = await Users.create({
+                        email:profile._json.kakao_account.email,
+                        nickname : profile.displayName,
+                        type:'SOCIAL',
+                        role:'BASIC',
+                        profileImg:profile.profile_image_url
+                    });
+                    done(null, newUser); // 회원가입하고 로그인 인증 완료
+                }
+            } catch(error) {
+                console.error(error);
+                done(error);
+            }
+        }
+    ))
+};
+
+export default kakaoStrategy;

--- a/server/src/api/routes/users/index.js
+++ b/server/src/api/routes/users/index.js
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import register from './register.js'
 import login from './login.js'
 import refresh from './refresh.js';
-
+import kakaoLogin from './kakaoLogin.js';
 /* 
  * users 디렉토리의 API들을 모두 내보낸다.
  * join, login, refresh, ...
@@ -13,6 +13,7 @@ export default (app) => { // Router() 함수를 매개변수로 받는다
 	refresh(app);
     register(app); 
 	login(app);
+	kakaoLogin(app);
 
 	return app
 }

--- a/server/src/api/routes/users/kakaoLogin.js
+++ b/server/src/api/routes/users/kakaoLogin.js
@@ -1,0 +1,27 @@
+import { Router } from "express";
+import passport from "passport";
+
+const router = Router();
+
+const kakao = (app) => {
+
+    app.use(router);
+
+    // 카카오 로그인을 get 요청을 하면 passport 인증을 하러 감.
+    router.get('/kakaoOuthLogin' , passport.authenticate('kakao'));
+
+    // 카카오 서버 로그인이 된다면, 카카오 redirect URL 설정에 따라 이쪽 라우터로 오게 됨.
+    router.get('/kakao/callback',
+    
+    // passport 로그인 전략에 의해 kakaoStrategy로 가서 카카오계정 정보와 DB를 비교하여 회원가입 진행.
+    passport.authenticate('kakao', {
+        failureRedirect:'/', // kakaoStrategy에서 실패한다면 실행됨.
+    }),
+    // kakaoStragegy에서 성공한다면 콜백 실행
+    (req, res) => {
+        res.redirect('/');
+    },
+    );
+}
+
+export default kakao;

--- a/server/src/loaders/express.js
+++ b/server/src/loaders/express.js
@@ -14,7 +14,13 @@ import nunjucks from "nunjucks";
 
 import fs from "fs";
 
+// 패스포트 등록
+import passport from "passport";
+import passportConfig from "../api/middlewares/passport/index.js";
+
 const expressLoader = (app) => {
+
+    passportConfig(); // 패스포트 설정
 
     /*
      * Health Check endpoints
@@ -60,13 +66,20 @@ const expressLoader = (app) => {
             secret: config.cookieSecret,
             resave: false,
             saveUninitialized: true,
-            store: new MySQLStore(options)
+            store: new MySQLStore(options),
+            cookie: {
+                httpOnly: true,
+                secure: false,
+             },
         })
     );
 
+    app.use(passport.initialize()); // 요청 객체에 passport 설정 심기
+    app.use(passport.session()); // req.session 객체에 passport 추가 저장
+
     // POST parameter read
     app.use(express.json());
-    app.use(express.urlencoded({extended:true}));
+    app.use(express.urlencoded({extended:false}));
 
     // cookie
     app.use(cookieParser(config.cookieSecret));


### PR DESCRIPTION
**1. passport 기능 추가**
- middlewares 디렉토리 아래 passport 디렉토리를 생성하여, kakaoStrategy와 디렉토리 entry point인 index.js 작성.
- session cookie 까지 생성된 것을 확인한 상태.

**2. kakaoOauthLogin 라우터 추가**
- 카카오 서버와 통신할 kakaoOauthLogin URL 과 데이터를 redirect 받을 URL 경로 또한 추가함.

**3. loaders 디렉토리 내 passport 기능과 OAuth를 사용하기 위해 부분변경**
- session option 내 session-cookie를 생성할 수 있도록 cookie 관련 option 추가.
- 아래와 같은 코드를 추가하여 요청 객체에 passport 설정을 심고, req.session 객체에 passport 추가 저장함.
```javascript
app.use(passport.initialize());
app.use(passport.session());
```