### PR TITLE
feat: related to attachs GET & POST API apply

### DIFF
--- a/server/src/api/routes/attachs.js
+++ b/server/src/api/routes/attachs.js
@@ -3,6 +3,7 @@ import logger from "winston";
 import Logger from "../../loaders/logger.js";
 import upload from "../middlewares/attachs/index.js";
 import Attachs from "../../models/attachs.js";
+import { Op } from "sequelize";
 
 const router = Router();
 const fileUpload = upload.fileUpload();
@@ -14,11 +15,72 @@ const attachs = (app) => {
     app.use("/attachs", router);
 
     /**
+     * 모든 게시글의 이미지 가져오기
+     * 모든 게시글 가져오는 API[/api/post]와 함께 호출되어야 한다.
+     */
+    router.get("/", async (req, res, next) => {
+        try {
+            const attachs = await Attachs.findAll({
+                order: [['createdAt', 'DESC']]
+            });
+            res.status(200).json({
+                code: 200,
+                msg: "success",
+                data: attachs
+            });
+        } catch(err) {
+            console.log(err);
+            logger.error(err);
+            next(err);
+        }
+    });
+
+    /**
+     * /api/attachs/posts/:postInfo
+     * 특정 게시글의 이미지 가져오기
+     * 하나의 게시글 가져오는 API[/api/posts/:postInfo]와 함께 호출되어야 한다.
+     * 게시글 등록 이미지와 댓글 이미지를 모두 가져온다.
+     * 임시로 router에서 비즈니스 로직을 처리하지만 service에서 처리하도록 수정해야 한다.
+     * 
+     */
+    router.get("/posts/:postInfo", async (req, res, next) => {
+        try {
+            const postId = req.params.postInfo;
+            const postImgPath = await Attachs.findAll({
+                where: { 
+                    img: {
+                        [Op.like]: "%post/" + postId
+                    } 
+                }
+            })
+            const commentImgPath = await Attachs.findAll({
+                where: {
+                    img: {
+                        [Op.like]: "%post/" + postId + "/comment/%"
+                    }
+                }
+            })
+            res.status(200).json({
+                code: 200,
+                msg: "success",
+                data: {
+                    "postAttachs": postImgPath,
+                    "commentAttachs": commentImgPath
+                }
+            });
+        } catch (err) {
+            console.log(err);
+            Logger.err(err);
+            next(err);
+        }
+    });
+
+     /**
      * Post(게시글)의 Attach(이미지 첨부파일) 업로드하기
      * 해당 API는 /api/posts 게시글 등록 API 작업 이후 호출된다.
      * 게시글의 이미지는 최소 1개부터 최대 5개까지 업로드할 수 있다.
      */
-    router.post("/posts", fileUpload.array("postImg", 5), async (req, res, next) => {
+     router.post("/posts", fileUpload.array("postImg", 5), async (req, res, next) => {
         try {
             logger.info("post-files: " + JSON.stringify(req.files));
             const files = req.files;
@@ -59,31 +121,6 @@ const attachs = (app) => {
         } catch (err) {
             console.log(err);
             logger.error(err);
-            next(err);
-        }
-    });
-
-    /**
-     * /api/posts/imgs/:postId
-     * 모든 게시글과 댓글의 이미지 가져오기
-     * 
-     * 임시로 router에서 비즈니스 로직을 처리하지만 service에서 처리하도록 수정해야 한다.
-     * 
-     */
-    router.get("/:postId", async (req, res, next) => {
-        try {
-            /** 
-             * 해당 게시글(postId)과 게시글에 연결된 댓글에 대한 첨부파일 이미지 가져오기 
-             */
-
-            res.status(200).json({
-                code: 200,
-                msg: "success",
-                data: {}
-            });
-        } catch (err) {
-            console.log(err);
-            Logger.err(err);
             next(err);
         }
     });

--- a/server/src/api/routes/posts.js
+++ b/server/src/api/routes/posts.js
@@ -20,7 +20,6 @@ const posts = (app) => {
      * 2. response JSON
      */
     router.get("/", async (req, res, next) => {
-        Logger.info("router: " + router);
         try {
             const posts = await Posts.findAll({
                 order: [['createdAt', 'DESC']]
@@ -40,7 +39,7 @@ const posts = (app) => {
     /**
      * /api/posts/:postInfo
      * postInfo: postId(게시글 PK)
-     * 하나의 게시글 가져오기
+     * 특정한 하나의 게시글 가져오기
      * 
      * 임시로 router에서 비즈니스 로직을 처리하지만 service에서 처리하도록 수정해야 한다.
      * 1. Read Parameter postId


### PR DESCRIPTION
게시글과 첨부파일 관련 API 구현 완료하였습니다.

1. 게시글 목록(메인)
- 모든 게시글 가져오기
- 모든 게시글의 이미지 가져오기

2. 게시글 상세
- 특정한 하나의 게시글 가져오기(댓글포함)
- 해당 게시글의 이미지 가져오기(댓글 포함)

3. 게시글 작성
- 게시글 등록하기
- 게시글의 이미지 파일 업로드하기

이상입니다. 
차후 댓글 관련 API 개발일정 정리하여 공유드리겠습니다.